### PR TITLE
refactor(analytics): 이벤트명 리터럴을 상수로 통일

### DIFF
--- a/lib/affiliate_benefits_screen.dart
+++ b/lib/affiliate_benefits_screen.dart
@@ -852,7 +852,7 @@ class _AffiliateBenefitsScreenState extends State<AffiliateBenefitsScreen> {
   void _selectCategory(String category) {
     if (_selectedCategory == category) return;
     AnalyticsLogger.logEvent(
-      'affiliate_category_click',
+      AnalyticsEvents.affiliateCategoryClick,
       parameters: {
         'category': category,
         'from_category': _selectedCategory,
@@ -1121,7 +1121,7 @@ class _AffiliateBenefitsScreenState extends State<AffiliateBenefitsScreen> {
       AffiliateRestaurantSummary restaurant) async {
     if (_isOpeningDetail) return;
     AnalyticsLogger.logEvent(
-      'affiliate_restaurant_click',
+      AnalyticsEvents.affiliateRestaurantClick,
       parameters: {
         'restaurant_id': restaurant.id,
         'restaurant_name': restaurant.name,

--- a/lib/config/analytics_events.dart
+++ b/lib/config/analytics_events.dart
@@ -36,6 +36,12 @@ class AnalyticsEvents {
   // 이벤트명은 그대로라 기존 데이터와 이어진다.
   static const String homeBannerClick = 'home_banner_click';
   static const String notificationOpen = 'notification_open';
+  static const String tabView = 'tab_view';
+  static const String couponPageView = 'coupon_page_view';
+  static const String affiliateCategoryClick = 'affiliate_category_click';
+  static const String affiliateRestaurantClick = 'affiliate_restaurant_click';
+  static const String referralCodeInputClick = 'referral_code_input_click';
+  static const String kakaoInviteClick = 'kakao_invite_click';
 
   // ===== 첫 쿠폰 보강 (룰렛·로그인) =====
   /// 룰렛 회전 시작 (연출 시작 시점, attempt_no: 1부터)

--- a/lib/coupon_list_screen.dart
+++ b/lib/coupon_list_screen.dart
@@ -241,7 +241,7 @@ class _CouponListScreenState extends State<CouponListScreen> {
   void initState() {
     super.initState();
     AnalyticsLogger.logEvent(
-      'coupon_page_view',
+      AnalyticsEvents.couponPageView,
       parameters: {
         if (widget.source != null) 'source': widget.source!,
       },

--- a/lib/main2.dart
+++ b/lib/main2.dart
@@ -9,6 +9,7 @@ import 'home.dart';
 import 'my.dart';
 import 'package:new1/services/api_client.dart';
 import 'package:new1/services/deep_link_service.dart';
+import 'package:new1/config/analytics_events.dart';
 import 'package:new1/utils/analytics_logger.dart';
 import 'package:new1/widgets/liquid_glass_bottom_bar.dart';
 
@@ -85,7 +86,7 @@ class _MainAppScreenState extends State<MainAppScreen> with WidgetsBindingObserv
     final tabName =
         index >= 0 && index < _tabNames.length ? _tabNames[index] : 'unknown';
     AnalyticsLogger.logEvent(
-      'tab_view',
+      AnalyticsEvents.tabView,
       parameters: {
         'tab_index': index,
         'tab_name': tabName,

--- a/lib/my.dart
+++ b/lib/my.dart
@@ -775,7 +775,7 @@ class _MyScreenState extends State<MyScreen> {
           leading: const Text('코드 입력하기', style: _kItemTitleStyle),
           trailing: _buildChevron(),
           onTap: () {
-            AnalyticsLogger.logEvent('referral_code_input_click');
+            AnalyticsLogger.logEvent(AnalyticsEvents.referralCodeInputClick);
             if (!isKakaoLoggedIn) {
               _promptLoginRequired();
               return;
@@ -990,7 +990,7 @@ class _MyScreenState extends State<MyScreen> {
                   )
                 : _buildChevron(),
             onTap: () {
-              AnalyticsLogger.logEvent('kakao_invite_click');
+              AnalyticsLogger.logEvent(AnalyticsEvents.kakaoInviteClick);
               if (!isKakaoLoggedIn) {
                 _promptLoginRequired();
                 return;


### PR DESCRIPTION
기존 7종이 발화부에 문자열 리터럴로 박혀 있어 오타가 나도 컴파일 단계에서
걸러지지 않았다. 실제로 이번 P0 작업 중 같은 이름을 여러 곳에 다시 적는
일이 반복돼, 계측 추가 전에 정리한다.

이벤트명 자체는 그대로라 기존에 쌓인 데이터와 이어진다.

tab_view · coupon_page_view · affiliate_category_click · affiliate_restaurant_click · referral_code_input_click · kakao_invite_click